### PR TITLE
アップロードファイルが取得できなかった場合のエラーを実装 fixes #1

### DIFF
--- a/app/Controllers/ActionController.php
+++ b/app/Controllers/ActionController.php
@@ -51,6 +51,9 @@ class ActionController extends ApiController
     public function postUpload(Request $request, Response $response): Response
     {
         $uploadedFiles = $request->getUploadedFiles();
+        if (empty($uploadedFiles)) {
+            return $this->errorResponse($response, 'Failed to get uploaded file.');
+        }
         /** @var UploadedFile */ 
         $uploadedFile = reset($uploadedFiles);
         if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {

--- a/tests/Controllers/ActionControllerTest.php
+++ b/tests/Controllers/ActionControllerTest.php
@@ -91,6 +91,24 @@ class ActionControllerTest extends TestCase
         $this->assertEquals($expected, $payload);
     }
     
+    /** @test */
+    public function testPostMediaWithEmptyFiles()
+    {
+        $app = $this->getAppInstance();
+        
+        $request = $this->createRequest('POST', '/api/twitter/media/upload');
+
+        $response = $app->handle($request);
+        $payload = (string)$response->getBody();
+        $expectedData = [
+            'code' => 10,
+            'error' => ['message' => 'Failed to get uploaded file.']
+        ];
+        $expected = json_encode($expectedData, JSON_PRETTY_PRINT);
+
+        $this->assertEquals($expected, $payload);
+    }
+    
 
     /** @test */
     public function testDeleteTweet()


### PR DESCRIPTION
ファイル名によってクライアントから送信されたファイルが取得できないことがあるため、取得できない場合はその旨をエラーで返却するように修正。