### PR TITLE
ファイルサイズのチェックを実装

### DIFF
--- a/packages/yagamuu/twitter/src/Constant.php
+++ b/packages/yagamuu/twitter/src/Constant.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace yagamuu\TwitterClientForRtainjapan;
+
+class Constant
+{
+    const MAX_FILE_SIZE_IMAGE = 5_000_000;
+    const MAX_FILE_SIZE_GIF_ANIME = 15_000_000;
+    const MAX_FILE_SIZE_VIDEO = 512_000_000;
+}

--- a/packages/yagamuu/twitter/src/Constant.php
+++ b/packages/yagamuu/twitter/src/Constant.php
@@ -5,7 +5,7 @@ namespace yagamuu\TwitterClientForRtainjapan;
 
 class Constant
 {
-    const MAX_FILE_SIZE_IMAGE = 5_000_000;
-    const MAX_FILE_SIZE_GIF_ANIME = 15_000_000;
-    const MAX_FILE_SIZE_VIDEO = 512_000_000;
+    const MAX_FILE_SIZE_IMAGE = 5000000;
+    const MAX_FILE_SIZE_GIF_ANIME = 15000000;
+    const MAX_FILE_SIZE_VIDEO = 512000000;
 }

--- a/packages/yagamuu/twitter/src/Twitter.php
+++ b/packages/yagamuu/twitter/src/Twitter.php
@@ -211,7 +211,7 @@ class Twitter
                     $upload = [];
                     foreach ($files as $file) {
                         $fileObj = new \SplFileObject($file, 'rb');
-                        self::validateFileSize($fileObj->getPath());
+                        self::validateFileSize($fileObj->getPathname());
                         $upload[] = $this->client->postMultipartAsync(
                             'media/upload',
                             [
@@ -223,8 +223,8 @@ class Twitter
                     $media_ids = implode(',', array_column($info, 'media_id_string'));
                 } else {
                     $file = $files[0];
-                    self::validateFileSize($file->getPath());
                     $video = new \SplFileObject($file, 'rb');
+                    self::validateFileSize($video->getPathname());
                     $method = self::isVideoFile($file) ? 'uploadVideoAsync' : 'uploadAnimeGifAsync';
                     $media_ids = (yield $this->client->$method($video))->media_id_string;
                 }

--- a/packages/yagamuu/twitter/src/ValidationErrorException.php
+++ b/packages/yagamuu/twitter/src/ValidationErrorException.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace yagamuu\TwitterClientForRtainjapan;
+
+use RuntimeException;
+use Throwable;
+
+class ValidationErrorException extends RuntimeException
+{
+    public function __construct(array $errors, int $code = 0, Throwable $previous = null)
+    {
+        $messages = [];
+        foreach ($errors as $key => $error) {
+            $messages[] = $key . '="' . $error . '"';
+        }
+        return parent::__construct(
+            implode(';', $messages),
+            $code,
+            $previous
+        );
+    }
+}

--- a/packages/yagamuu/twitter/tests/TwitterTest.php
+++ b/packages/yagamuu/twitter/tests/TwitterTest.php
@@ -9,12 +9,12 @@ use mpyw\Cowitter\Client;
 use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamFile;
+use phpDocumentor\Reflection\DocBlock\Tags\Example;
 use Phpfastcache\CacheManager;
 use Phpfastcache\Config\Config;
 use yagamuu\TwitterClientForRtainjapan\Twitter;
 use yagamuu\TwitterClientForRtainjapan\Tests\CacheManagerProvider;
 use yagamuu\TwitterClientForRtainjapan\Tests\Examples;
-use yagamuu\TwitterClientForRtainjapan\ValidationErrorException;
 
 class TwitterTest extends TestCase
 {
@@ -284,7 +284,7 @@ class TwitterTest extends TestCase
 
     /**
      * @test
-     * @dataProvider invalidFileProvider
+     * @dataProvider provideLargeMedia
      */
     public function testPostTweetWithLargeMedias(vfsStreamFile $file, string $message):void
     {
@@ -301,6 +301,12 @@ class TwitterTest extends TestCase
         ];
 
         $mock_client = $this->client_builder->getMock();
+        $mock_client->expects($this->any())
+                ->method('get')
+                ->withConsecutive([
+                    $this->equalTo('statuses/update'),
+                    $this->equalTo(['status' => 'Hello, Twitter!', 'media_ids' => '1'])])
+                ->willReturn(Examples\GetStatusesUserTimelines::example());
 
         $twitter = new Twitter($mock_client, $this->cache);
 
@@ -309,7 +315,7 @@ class TwitterTest extends TestCase
         ]);
 
         $this->assertEquals([
-            'errors' => [$files['name'] . '="' . $message . '"'],
+            'errors' => [$files['name'][0] . '="' . $message . '"'],
             'informations' => []
         ], $response);
     }

--- a/packages/yagamuu/twitter/tests/TwitterTest.php
+++ b/packages/yagamuu/twitter/tests/TwitterTest.php
@@ -6,12 +6,15 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use PHPUnit\Framework\TestCase;
 
 use mpyw\Cowitter\Client;
+use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamFile;
 use Phpfastcache\CacheManager;
 use Phpfastcache\Config\Config;
 use yagamuu\TwitterClientForRtainjapan\Twitter;
 use yagamuu\TwitterClientForRtainjapan\Tests\CacheManagerProvider;
 use yagamuu\TwitterClientForRtainjapan\Tests\Examples;
+use yagamuu\TwitterClientForRtainjapan\ValidationErrorException;
 
 class TwitterTest extends TestCase
 {
@@ -279,6 +282,38 @@ class TwitterTest extends TestCase
         ], $response);
     }
 
+    /**
+     * @test
+     * @dataProvider invalidFileProvider
+     */
+    public function testPostTweetWithLargeMedias(vfsStreamFile $file, string $message):void
+    {
+        $root = vfsStream::setup('root');
+        $mockFile = $file->at($root);
+        $files = [
+            'name' => [$mockFile->getName()],
+            'type' => [mime_content_type($mockFile->url())],
+            'size' => [$mockFile->size()],
+            'tmp_name' => [
+                $mockFile->url()
+            ],
+            'error' => [UPLOAD_ERR_OK]
+        ];
+
+        $mock_client = $this->client_builder->getMock();
+
+        $twitter = new Twitter($mock_client, $this->cache);
+
+        $response = $twitter->postTweet('Hello, Twitter!', [
+            'media' => $files
+        ]);
+
+        $this->assertEquals([
+            'errors' => [$files['name'] . '="' . $message . '"'],
+            'informations' => []
+        ], $response);
+    }
+
     /** @dataProvider invalidFileProvider */
     public function testCatchRuntimeExceptionOnPostTweet($files):void
     {
@@ -369,6 +404,47 @@ class TwitterTest extends TestCase
             'errors'          => [],
             'media_id_string' => '1'
         ], $response);
+    }
+
+    /**
+     * @test
+     * @dataProvider provideLargeMedia
+     */
+    public function testUploadOverSizeImage(vfsStreamFile $file, string $message): void
+    {
+        $root = vfsStream::setup('root');
+        $mockFile =$file->at($root);
+        $files = [
+            'name' => $mockFile->getName(),
+            'type' => mime_content_type($mockFile->url()),
+            'size' => $mockFile->size(),
+            'tmp_name' => $mockFile->url(),
+            'error' => [UPLOAD_ERR_OK]
+        ];
+
+        $media_api_responses = [
+            Examples\PostMediaUpload::example()
+        ];
+        $media_api_responses[0]->media_id = 1;
+        $media_api_responses[0]->media_id_string = '1';
+
+        $mock_client = $this->client_builder->getMock();
+        $twitter = new Twitter($mock_client, $this->cache);
+
+        $response = $twitter->uploadMedia($files['tmp_name'], $files['type'], $files['name']);
+        $this->assertEquals([
+            'errors'          => [$files['name'] . '="' . $message . '"'],
+            'media_id_string' => ''
+        ], $response);
+    }
+    
+    public function provideLargeMedia(): array {
+        return [
+            [
+                vfsStream::newFile('big.jpg')->setContent(LargeFileContent::withMegabytes(6)),
+                'Image size must be <= 5000000 bytes'
+            ]
+        ];
     }
 
     public function testGetSearchTweet():void


### PR DESCRIPTION
https://developer.twitter.com/en/docs/media/upload-media/uploading-media/media-best-practices

Twitter APIの仕様に従ってファイルサイズチェックを実装
Cowitterからのエラーレスポンスではなく、APIとしてエラーを返すようになります

`TwitterTest.php`のdiffが無駄に大きくなってしまっていますが、画像サイズ周りのテストを追加しました。