### PR TITLE
引用リツイート、返信機能の実装

### DIFF
--- a/app/Controllers/ActionController.php
+++ b/app/Controllers/ActionController.php
@@ -29,7 +29,7 @@ class ActionController extends ApiController
     public function postTweet(Request $request, Response $response)
     {
         $data = $request->getParsedBody();
-        $result = $this->twitter->postUpdate($data['status'] ?? '', $data['media_ids'] ?? []);
+        $result = $this->twitter->postUpdate($data['status'] ?? '', $data['media_ids'] ?? [], $data);
 
         if (count($result['errors']) > 0) {
             return $this->errorResponse($response, implode(PHP_EOL, $result['errors']));

--- a/packages/yagamuu/twitter/composer.json
+++ b/packages/yagamuu/twitter/composer.json
@@ -18,7 +18,7 @@
         "vlucas/phpdotenv": "^3.4",
         "twig/twig": "^2.11",
         "twig/extensions": "^1.5",
-        "phpFastCache/phpFastCache": "^7.0"
+        "phpfastcache/phpfastcache": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/yagamuu/twitter/src/Twitter.php
+++ b/packages/yagamuu/twitter/src/Twitter.php
@@ -371,6 +371,7 @@ class Twitter
         foreach ($options as $key => $value) {
             if ($key === 'in_reply_to_status_id') {
                 $request['in_reply_to_status_id'] = $value;
+                $request['auto_populate_reply_metadata'] = true;
             }
             if ($key === 'attachment_url' && filter_var($value, FILTER_VALIDATE_URL) && preg_match('|^https?://twitter.com/.*$|', $value)) {
                 $request['attachment_url'] = $value;

--- a/packages/yagamuu/twitter/src/Twitter.php
+++ b/packages/yagamuu/twitter/src/Twitter.php
@@ -298,9 +298,10 @@ class Twitter
      * ツイートの投稿を行う
      * @param string $status ツイート本文
      * @param array $media_ids アップロードしたいメディアのid
+     * @param array $options その他パラメーター
      * @return array
      */
-    public function postUpdate(string $status, array $media_ids = []): array
+    public function postUpdate(string $status, array $media_ids = [], array $options = []): array
     {
         $user_timelines = [];
         $errors = [];
@@ -308,6 +309,10 @@ class Twitter
         $request = ['status' => $status ?? ''];
         if (count($media_ids) > 0) {
             $request['media_ids'] = implode(',', $media_ids);
+        }
+
+        if (!empty($options)) {
+            $request = self::setRequestOptionParam($request, $options);
         }
 
         try {
@@ -359,6 +364,19 @@ class Twitter
             'errors'          => $errors,
             'media_id_string' => $media_id_string
         ];
+    }
+
+    private static function setRequestOptionParam(array $request, array $options): array
+    {
+        foreach ($options as $key => $value) {
+            if ($key === 'in_reply_to_status_id') {
+                $request['in_reply_to_status_id'] = $value;
+            }
+            if ($key === 'attachment_url' && filter_var($value, FILTER_VALIDATE_URL) && preg_match('|^https?://twitter.com/.*$|', $value)) {
+                $request['attachment_url'] = $value;
+            }
+        }
+        return $request;
     }
 
     private static function validateFileSize(string $path, string $submitFileName): bool

--- a/tests/Controllers/ActionControllerTest.php
+++ b/tests/Controllers/ActionControllerTest.php
@@ -8,6 +8,7 @@ use DI\Container;
 use yagamuu\TwitterClientForRtainjapan\Twitter;
 use yagamuu\TwitterClientForRtainjapan\Tests\Examples\GetStatusesUserTimelines;
 use org\bovigo\vfs\vfsStream;
+use Prophecy\Prophecy\ObjectProphecy;
 use Slim\Psr7\UploadedFile;
 
 class ActionControllerTest extends TestCase
@@ -21,10 +22,22 @@ class ActionControllerTest extends TestCase
         /** @var Container */
         $container = $app->getContainer();
         
+        $request_body = [
+            'status' => 'Hello, Twitter!',
+            'media_ids' => []
+        ];
+        
         // Twitterクラスのモックオブジェクト
         $twitterProphecy = $this->prophesize(Twitter::class);
         $twitterProphecy
-            ->postUpdate('Hello, Twitter!', [])
+            ->postUpdate(
+                'Hello, Twitter!',
+                [],
+                [
+                    'status' => 'Hello, Twitter!',
+                    'media_ids' => []
+                ]
+            )
             ->willReturn([
                 'errors' => [],
                 'data' => GetStatusesUserTimelines::example()
@@ -34,11 +47,6 @@ class ActionControllerTest extends TestCase
         // DIコンテナにTwitterモックを設定
         $container->set(Twitter::class, $twitterProphecy->reveal());
 
-        $request_body = [
-            'status' => 'Hello, Twitter!',
-            'media_ids' => []
-        ];
-        
         $request = $this->createRequest('POST', '/api/twitter/statuses/update');
         $request = $request->withParsedBody($request_body);
         $response = $app->handle($request);


### PR DESCRIPTION
https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update

そのままクライアントアプリから渡されるKey名通りTwitterクライアントに投げてます。
メソッドの実装等見直した方が良い気もしますが、多分いずれフルスクラッチで作り直すので一旦これで……