### PR TITLE
長文ツイートへの全文取得、メディア取得に対応する

### DIFF
--- a/packages/yagamuu/twitter/src/Twitter.php
+++ b/packages/yagamuu/twitter/src/Twitter.php
@@ -38,6 +38,7 @@ class Twitter
         try {
             $user_timelines = $this->client->get('statuses/user_timeline', [
                 'screen_name' => getenv('SCREEN_NAME'),
+                'tweet_mode'  => 'extended',
                 'count'       => 10
             ]);
 
@@ -73,7 +74,8 @@ class Twitter
 
         try {
             $mentions_timelines = $this->client->get('statuses/mentions_timeline', [
-                'count'       => 10
+                'count'       => 10,
+                'tweet_mode'  => 'extended'
             ]);
 
             // キャッシュの更新
@@ -279,6 +281,7 @@ class Twitter
             $result = $this->client->get('search/tweets', [
                 'q' => $query,
                 'count' => $count,
+                'tweet_mode'  => 'extended',
                 'result_type' => 'recent'
             ]);
             

--- a/packages/yagamuu/twitter/tests/TwitterTest.php
+++ b/packages/yagamuu/twitter/tests/TwitterTest.php
@@ -59,6 +59,7 @@ class TwitterTest extends TestCase
                     $this->equalTo(
                         [
                             'screen_name' => getenv('SCREEN_NAME'),
+                            'tweet_mode'  => 'extended',
                             'count'       => 10
                         ]
                     )
@@ -85,6 +86,7 @@ class TwitterTest extends TestCase
                     $this->equalTo(
                         [
                             'screen_name' => getenv('SCREEN_NAME'),
+                            'tweet_mode'  => 'extended',
                             'count'       => 10
                         ]
                     )
@@ -108,7 +110,7 @@ class TwitterTest extends TestCase
                 ->method('get')
                 ->with(
                     $this->equalTo('statuses/mentions_timeline'),
-                    $this->equalTo(['count' => 10])
+                    $this->equalTo(['count' => 10, 'tweet_mode' => 'extended'])
                 )->willReturn($api_response);
 
         $twitter = new Twitter($mock_client, $this->cache);
@@ -129,7 +131,7 @@ class TwitterTest extends TestCase
                 ->method('get')
                 ->with(
                     $this->equalTo('statuses/mentions_timeline'),
-                    $this->equalTo(['count' => 10])
+                    $this->equalTo(['count' => 10, 'tweet_mode'  => 'extended'])
                 )->willThrowException(new \RuntimeException($excepted_message));
                 
         $twitter = new Twitter($mock_client, $this->cache);
@@ -465,6 +467,7 @@ class TwitterTest extends TestCase
                         [
                             'q' => 'search test',
                             'count' => 15,
+                            'tweet_mode'  => 'extended',
                             'result_type' => 'recent'
                         ]
                     )
@@ -492,6 +495,7 @@ class TwitterTest extends TestCase
                         [
                             'q' => 'error test',
                             'count' => 15,
+                            'tweet_mode'  => 'extended',
                             'result_type' => 'recent'
                         ]
                     )
@@ -526,6 +530,7 @@ class TwitterTest extends TestCase
                 $this->equalTo(
                     [
                         'screen_name' => getenv('SCREEN_NAME'),
+                        'tweet_mode'  => 'extended',
                         'count'       => 10
                     ]
                 )


### PR DESCRIPTION
長文のツイートを取得した場合は従来の方法ではツイート本文の末尾が省略され、かつメディア情報の取得ができませんでした。
その為リクエストパラメーターに`tweet_mode=extended`を含めることで対応しました。
http://web.archive.org/web/20170302204537/https://dev.twitter.com/overview/api/upcoming-changes-to-tweets